### PR TITLE
require('cl') in bin/rock

### DIFF
--- a/bin/rock
+++ b/bin/rock
@@ -7,6 +7,7 @@ var P = require('autoresolve')
   , fs = require('fs-extra')
   , path = require('path')
   , nom = require('nomnom')
+  , cl = require('cl')
 
 
 /*program.version(require('../package.json').version)


### PR DESCRIPTION
Was getting the error below when trying to create file from custom rock. I saw cl in your node_modules, so I
required cl. Seemed to solve the issue.

Error:

/usr/local/lib/node_modules/rock/bin/rock:35
if (err) cl.exit(1, err)
^
ReferenceError: cl is not defined
