### PR TITLE
Misc. Bugfixes

### DIFF
--- a/bin/rock
+++ b/bin/rock
@@ -38,7 +38,7 @@ if (opts.rock && !opts.file) {
 
 if (opts.rock && opts.file) {
   if (opts.topen && opts.tclose) {
-    config.tokens = {open: topen, close: tclose}
+    config.tokens = {open: opts.topen, close: opts.tclose}
   }
 
   rock.fetchFile(opts.path, opts.rock, config, function(err) {

--- a/lib/tweezers.js
+++ b/lib/tweezers.js
@@ -27,6 +27,7 @@ function readFilesAndExtract (files, open, close, callback) {
   batch(files).par(8)
   .each(function(i, file, next) {
     readFileAndExtract(file, function(err, obj) {
+      if (err) return callback(err)
       rutil.extend(tokens, obj)
       fileObj[file] = Object.keys(obj)
       next()


### PR DESCRIPTION
Fixes the error: 

```
    config.tokens = {open: topen, close: tclose}
                           ^

ReferenceError: topen is not defined
    at Object.<anonymous> (/home/ryan/.nvm/versions/node/v6.4.0/lib/node_modules/rock/bin/rock:41:28)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```

when running rock with the `-f` flag.

---

Added missing error handler to lib/tweezers.js.