### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"


### PR DESCRIPTION
We need a `.travis.yml` since this isn't ruby: https://travis-ci.org/rocktemplates/rock/builds/157651880.

@jprichardson Do you want to support 0.12 as well? (I don't bother.)

Feel free to squash-merge.