### PR TITLE
BREAKING: Do not copy .git directory from local rock

### DIFF
--- a/lib/rock.js
+++ b/lib/rock.js
@@ -82,7 +82,9 @@ function fetchRepo (projectPath, repoPath, options, callback) {
   fs.exists(repoPath, copyOrDownload)
   function copyOrDownload (itsLocal) {
     if (itsLocal) {
-      fs.copy(repoPath, projectPath, checkRockConf)
+      fs.copy(repoPath, projectPath, {filter: function (p) {
+        return !/.*\/\.git$/.test(p)
+      }}, checkRockConf)
     } else {
       ghdownload(repoPath, projectPath)
       .on('error', callback)


### PR DESCRIPTION
Fixes #19 

Had to use a function to invert the regex.